### PR TITLE
Fix // CMake + MSVC generator // build fail due missed header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,9 @@ include_directories(
 	${CMAKE_CURRENT_BINARY_DIR}
 )
 if(MSVC)
+	if(NOT HAVE_INTTYPES_H)
+		include_directories(${PROJECT_SOURCE_DIR}/build/wp8/ortp)
+	endif()
 	include_directories(${CMAKE_PREFIX_PATH}/include/MSVC)
 endif()
 


### PR DESCRIPTION
Hello,

Environment:
Windows 7/MSVC 2012

How to reproduce:
cmake <path to ortp clone>
cmake --build . --config Release

Error:
C:\WORK\GITHUB\dev\ortp\src\ortp.c(25): fatal error C1083: Cannot open include file: 'inttypes.h': No such file or directory [C:\WORK\GITHUB\dev\ortp\1\src\ortp.vcxproj]

Proposal fix will add additional include path to generated build.