### PR TITLE
constify mime_type of PayloadType structure

### DIFF
--- a/include/ortp/payloadtype.h
+++ b/include/ortp/payloadtype.h
@@ -73,7 +73,7 @@ struct _PayloadType
 	int pattern_length;
 	/* other useful information for the application*/
 	int normal_bitrate;	/*in bit/s */
-	char *mime_type; /**<actually the submime, ex: pcm, pcma, gsm*/
+	const char *mime_type; /**<actually the submime, ex: pcm, pcma, gsm*/
 	int channels; /**< number of channels of audio */
 	char *recv_fmtp; /* various format parameters for the incoming stream */
 	char *send_fmtp; /* various format parameters for the outgoing stream */

--- a/src/payloadtype.c
+++ b/src/payloadtype.c
@@ -49,7 +49,7 @@ PayloadType *payload_type_clone(const PayloadType *payload)
 {
 	PayloadType *newpayload=(PayloadType *)ortp_new0(PayloadType,1);
 	memcpy(newpayload,payload,sizeof(PayloadType));
-	newpayload->mime_type=ortp_strdup(payload->mime_type);
+	newpayload->mime_type=payload->mime_type;
 	if (payload->recv_fmtp!=NULL) {
 		newpayload->recv_fmtp=ortp_strdup(payload->recv_fmtp);
 	}
@@ -133,7 +133,6 @@ void payload_type_set_avpf_params(PayloadType *pt, PayloadTypeAvpfParams params)
 **/
 void payload_type_destroy(PayloadType *pt)
 {
-	if (pt->mime_type) ortp_free(pt->mime_type);
 	if (pt->recv_fmtp) ortp_free(pt->recv_fmtp);
 	if (pt->send_fmtp) ortp_free(pt->send_fmtp);
 	ortp_free(pt);


### PR DESCRIPTION
This is needed for proper memory management of payload types defined in
avprofile.c, and improves global memory usage and performance.

Signed-off-by: Lionel Orry <lionel.orry@gmail.com>