### PR TITLE
Fixed uninitialized variable crash on linux

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -31,7 +31,7 @@ void rtp_scheduler_init(RtpScheduler *sched)
 	sched->list=0;
 	sched->time_=0;
 	/* default to the posix timer */
-#if defined(_WIN32) && !defined(ORTP_WINDOWS_UNIVERSAL)
+#if (defined(_WIN32) && !defined(ORTP_WINDOWS_UNIVERSAL)) || !defined(_WIN32)
 	rtp_scheduler_set_timer(sched,&posix_timer);
 #endif
 	ortp_mutex_init(&sched->lock,NULL);


### PR DESCRIPTION
This patch fixes a Segmentation Fault right after a `ortp_scheduler_init()` call.
The segmentation fault happens (only?) on a linux based OS at `scheduler.c:111`, when `timer->timer_init()` is called but `timer` is not initialized.