### PR TITLE
fix compile warning

### DIFF
--- a/src/rtpsession_inet.c
+++ b/src/rtpsession_inet.c
@@ -346,11 +346,11 @@ void _rtp_session_apply_socket_sizes(RtpSession * session){
 int
 rtp_session_set_local_addr (RtpSession * session, const char * addr, int rtp_port, int rtcp_port)
 {
+	ortp_socket_t sock;
+	int sockfamily;
 	// Stop async rtp recv thread before recreating the socket
 	rtp_session_reset_recvfrom(session);
 
-	ortp_socket_t sock;
-	int sockfamily;
 	if (session->rtp.gs.socket!=(ortp_socket_t)-1){
 		/* don't rebind, but close before*/
 		_rtp_session_release_sockets(session, FALSE);


### PR DESCRIPTION
rtpsession_inet.c: In function 'rtp_session_set_local_addr':
rtpsession_inet.c:352:2: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
  ortp_socket_t sock;
  ^
cc1: all warnings being treated as errors
gcc (Debian 4.9.2-10) 4.9.2
