### PR TITLE
rtpsession_inet.c: define IPV6_RECVDSTADDR if undefined on legacy MacOS

### DIFF
--- a/src/rtpsession_inet.c
+++ b/src/rtpsession_inet.c
@@ -24,6 +24,12 @@
 
 #if __APPLE__
 #include "TargetConditionals.h"
+#ifndef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#endif
+#ifndef IPV6_RECVDSTADDR
+#define IPV6_RECVDSTADDR 7
+#endif
 #endif
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
Some versions of macOS may not have `IPV6_RECVDSTADDR` defined: while xnu headers have it, it may be disabled. For example: https://opensource.apple.com/source/xnu/xnu-2782.30.5/bsd/netinet6/in6.h.auto.html
This breaks the build, since the code sets this as a fallback.