### PR TITLE
Fix out-of-bounds reads in RTCP XR block accessor functions

### DIFF
--- a/src/rtcpparse.c
+++ b/src/rtcpparse.c
@@ -345,6 +345,7 @@ uint32_t rtcp_XR_get_ssrc(const mblk_t *m) {
 
 uint64_t rtcp_XR_rcvr_rtt_get_ntp_timestamp(const mblk_t *m) {
 	uint64_t ts = 0;
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_rcvr_rtt_report_block_t)) return 0;
 	rtcp_xr_rcvr_rtt_report_block_t *b = (rtcp_xr_rcvr_rtt_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	ts = ntohl(b->ntp_timestamp_msw);
 	ts <<= 32;
@@ -353,227 +354,265 @@ uint64_t rtcp_XR_rcvr_rtt_get_ntp_timestamp(const mblk_t *m) {
 }
 
 uint32_t rtcp_XR_dlrr_get_ssrc(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_generic_block_header_t) + sizeof(rtcp_xr_dlrr_report_subblock_t)) return 0;
 	rtcp_xr_dlrr_report_subblock_t *b = (rtcp_xr_dlrr_report_subblock_t *)(m->b_rptr + sizeof(rtcp_xr_header_t) +
 	                                                                       sizeof(rtcp_xr_generic_block_header_t));
 	return ntohl(b->ssrc);
 }
 
 uint32_t rtcp_XR_dlrr_get_lrr(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_generic_block_header_t) + sizeof(rtcp_xr_dlrr_report_subblock_t)) return 0;
 	rtcp_xr_dlrr_report_subblock_t *b = (rtcp_xr_dlrr_report_subblock_t *)(m->b_rptr + sizeof(rtcp_xr_header_t) +
 	                                                                       sizeof(rtcp_xr_generic_block_header_t));
 	return ntohl(b->lrr);
 }
 
 uint32_t rtcp_XR_dlrr_get_dlrr(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_generic_block_header_t) + sizeof(rtcp_xr_dlrr_report_subblock_t)) return 0;
 	rtcp_xr_dlrr_report_subblock_t *b = (rtcp_xr_dlrr_report_subblock_t *)(m->b_rptr + sizeof(rtcp_xr_header_t) +
 	                                                                       sizeof(rtcp_xr_generic_block_header_t));
 	return ntohl(b->dlrr);
 }
 
 uint8_t rtcp_XR_stat_summary_get_flags(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_generic_block_header_t)) return 0;
 	rtcp_xr_generic_block_header_t *bh = (rtcp_xr_generic_block_header_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return bh->flags;
 }
 
 uint32_t rtcp_XR_stat_summary_get_ssrc(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->ssrc);
 }
 
 uint16_t rtcp_XR_stat_summary_get_begin_seq(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->begin_seq);
 }
 
 uint16_t rtcp_XR_stat_summary_get_end_seq(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->end_seq);
 }
 
 uint32_t rtcp_XR_stat_summary_get_lost_packets(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->lost_packets);
 }
 
 uint32_t rtcp_XR_stat_summary_get_dup_packets(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->dup_packets);
 }
 
 uint32_t rtcp_XR_stat_summary_get_min_jitter(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->min_jitter);
 }
 
 uint32_t rtcp_XR_stat_summary_get_max_jitter(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->max_jitter);
 }
 
 uint32_t rtcp_XR_stat_summary_get_mean_jitter(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->mean_jitter);
 }
 
 uint32_t rtcp_XR_stat_summary_get_dev_jitter(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->dev_jitter);
 }
 
 uint8_t rtcp_XR_stat_summary_get_min_ttl_or_hl(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->min_ttl_or_hl;
 }
 
 uint8_t rtcp_XR_stat_summary_get_max_ttl_or_hl(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->max_ttl_or_hl;
 }
 
 uint8_t rtcp_XR_stat_summary_get_mean_ttl_or_hl(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->mean_ttl_or_hl;
 }
 
 uint8_t rtcp_XR_stat_summary_get_dev_ttl_or_hl(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_stat_summary_report_block_t)) return 0;
 	rtcp_xr_stat_summary_report_block_t *b =
 	    (rtcp_xr_stat_summary_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->dev_ttl_or_hl;
 }
 
 uint32_t rtcp_XR_voip_metrics_get_ssrc(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohl(b->ssrc);
 }
 
 uint8_t rtcp_XR_voip_metrics_get_loss_rate(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->loss_rate;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_discard_rate(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->discard_rate;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_burst_density(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->burst_density;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_gap_density(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->gap_density;
 }
 
 uint16_t rtcp_XR_voip_metrics_get_burst_duration(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->burst_duration);
 }
 
 uint16_t rtcp_XR_voip_metrics_get_gap_duration(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->gap_duration);
 }
 
 uint16_t rtcp_XR_voip_metrics_get_round_trip_delay(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->round_trip_delay);
 }
 
 uint16_t rtcp_XR_voip_metrics_get_end_system_delay(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->end_system_delay);
 }
 
 uint8_t rtcp_XR_voip_metrics_get_signal_level(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->signal_level;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_noise_level(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->noise_level;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_rerl(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->rerl;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_gmin(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->gmin;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_r_factor(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->r_factor;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_ext_r_factor(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->ext_r_factor;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_mos_lq(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->mos_lq;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_mos_cq(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->mos_cq;
 }
 
 uint8_t rtcp_XR_voip_metrics_get_rx_config(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return b->rx_config;
 }
 
 uint16_t rtcp_XR_voip_metrics_get_jb_nominal(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->jb_nominal);
 }
 
 uint16_t rtcp_XR_voip_metrics_get_jb_maximum(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->jb_maximum);
 }
 
 uint16_t rtcp_XR_voip_metrics_get_jb_abs_max(const mblk_t *m) {
+	if (msgdsize(m) < sizeof(rtcp_xr_header_t) + sizeof(rtcp_xr_voip_metrics_report_block_t)) return 0;
 	rtcp_xr_voip_metrics_report_block_t *b =
 	    (rtcp_xr_voip_metrics_report_block_t *)(m->b_rptr + sizeof(rtcp_xr_header_t));
 	return ntohs(b->jb_abs_max);


### PR DESCRIPTION
## Summary

- Add `msgdsize()` bounds validation to all RTCP XR block accessor functions before dereferencing block-type structs
- Prevents heap over-reads when processing crafted RTCP XR packets

## Details

`rtcp_is_XR()` validates only `MIN_RTCP_XR_PACKET_SIZE` (12 bytes), but the accessor functions dereference structs that require 20-44+ bytes depending on block type:

- `rtcp_xr_rcvr_rtt_report_block_t`: 12 bytes (needs 20 total)
- `rtcp_xr_dlrr_report_subblock_t`: 12 bytes at offset 12 (needs 24 total)
- `rtcp_xr_stat_summary_report_block_t`: 40 bytes (needs 48 total)
- `rtcp_xr_voip_metrics_report_block_t`: 36 bytes (needs 44 total)

A crafted RTCP XR packet of exactly 12 bytes passes validation but causes heap over-reads in the accessors. For `rtcp_XR_rcvr_rtt_get_ntp_timestamp()`, the leaked 8 bytes are stored in `stats->last_rcvr_rtt_ts` and reflected to the sender in DLRR responses.