### PR TITLE
Fix out-of-bounds array read in rtp_remap_header_extension_ids()

### DIFF
--- a/src/rtpsession.c
+++ b/src/rtpsession.c
@@ -2865,11 +2865,12 @@ void rtp_remap_header_extension_ids(mblk_t *packet, const int mapping[16]) {
 				continue;
 			}
 
+			if (tmp + 1 >= ext_header + ext_header_size) break;
 			id = tmp[0];
 			size = (size_t)tmp[1];
 
 			// Remap the extension id according to the provided array
-			if (mapping[id] > 0) tmp[0] = (uint8_t)mapping[id];
+			if (id < 16 && mapping[id] > 0) tmp[0] = (uint8_t)mapping[id];
 
 			tmp += size + 2;
 		}


### PR DESCRIPTION
## Summary

- Add bounds check for extension ID before indexing `mapping[16]` in the 2-byte header extension path
- Add bounds check for the size byte read to prevent 1-byte over-read at buffer end

## Details

In the 2-byte header extension path of `rtp_remap_header_extension_ids()`, the extension ID is read as `id = tmp[0]` (range 0-255) from attacker-controlled RTP packet data, then used to index `mapping[16]`. When `id >= 16`, this reads up to 960 bytes past the mapping array.

The 1-byte header path (profile 0xBEDE) is already safe: `id = *tmp >> 4` produces values in range 0-15. This fix adds the equivalent constraint to the 2-byte path.