### PR TITLE
Fix integer underflow in rtcp_PSFB_rpsi_get_fci_bit_string_len()

### DIFF
--- a/src/rtcpparse.c
+++ b/src/rtcpparse.c
@@ -712,8 +712,10 @@ rtcp_fb_rpsi_fci_t *rtcp_PSFB_rpsi_get_fci(const mblk_t *m) {
 }
 
 uint16_t rtcp_PSFB_rpsi_get_fci_bit_string_len(const mblk_t *m) {
+	size_t required = sizeof(rtcp_common_header_t) + sizeof(rtcp_fb_header_t) + 2;
+	size_t pkt_size = rtcp_get_size(m);
+	if (pkt_size < required) return 0;
 	rtcp_fb_rpsi_fci_t *fci = rtcp_PSFB_rpsi_get_fci(m);
-	uint16_t bit_string_len_in_bytes =
-	    (uint16_t)(rtcp_get_size(m) - (sizeof(rtcp_common_header_t) + sizeof(rtcp_fb_header_t) + 2));
+	uint16_t bit_string_len_in_bytes = (uint16_t)(pkt_size - required);
 	return ((bit_string_len_in_bytes * 8) - fci->pb);
 }


### PR DESCRIPTION
## Summary

- Add size validation before the subtraction that computes RPSI FCI bit string length
- Prevents integer underflow when packet size is less than the expected minimum

## Details

`rtcp_PSFB_rpsi_get_fci_bit_string_len()` computes `rtcp_get_size(m) - 14` but `rtcp_is_PSFB()` only validates `MIN_RTCP_PSFB_PACKET_SIZE` (12 bytes). When the packet is 12-13 bytes, the subtraction underflows as `size_t`, and the cast to `uint16_t` produces ~65534. The function then returns ~65520 as the bit string length, causing callers to read far past the packet buffer.

Additionally, `rtcp_PSFB_rpsi_get_fci()` dereferences at offset 12 without a size check, causing a 1-byte heap over-read of `fci->pb` on a 12-byte packet.